### PR TITLE
feat: Modify current routes template

### DIFF
--- a/stubs/routes.blade.php
+++ b/stubs/routes.blade.php
@@ -3,13 +3,13 @@ Route::controller({{$entity}}Controller::class)->group(function () {
     Route::post('{{$entities}}', 'create');
 @endif
 @if (in_array('U', $options))
-    Route::put('{{$entities}}/{id}', 'update');
+    Route::put('{{$entities}}/{id}', 'update')->whereNumber('id');
 @endif
 @if (in_array('D', $options))
-    Route::delete('{{$entities}}/{id}', 'delete');
+    Route::delete('{{$entities}}/{id}', 'delete')->whereNumber('id');
 @endif
 @if (in_array('R', $options))
-    Route::get('{{$entities}}/{id}', 'get');
+    Route::get('{{$entities}}/{id}', 'get')->whereNumber('id');
     Route::get('{{$entities}}', 'search');
 @endif
 });

--- a/tests/ControllerGeneratorTest.php
+++ b/tests/ControllerGeneratorTest.php
@@ -140,9 +140,9 @@ class ControllerGeneratorTest extends TestCase
         $this->assertEventPushedChain([
             SuccessCreateMessage::class => [
                 "Created a new Route: Route::post('posts', 'create');",
-                "Created a new Route: Route::put('posts/{id}', 'update');",
-                "Created a new Route: Route::delete('posts/{id}', 'delete');",
-                "Created a new Route: Route::get('posts/{id}', 'get');",
+                "Created a new Route: Route::put('posts/{id}', 'update')->whereNumber('id');",
+                "Created a new Route: Route::delete('posts/{id}', 'delete')->whereNumber('id');",
+                "Created a new Route: Route::get('posts/{id}', 'get')->whereNumber('id');",
                 "Created a new Route: Route::get('posts', 'search');",
                 'Created a new Controller: PostController',
             ],

--- a/tests/fixtures/CommandTest/routes.php
+++ b/tests/fixtures/CommandTest/routes.php
@@ -5,8 +5,8 @@ use App\Http\Controllers\PostController;
 
 Route::controller(PostController::class)->group(function () {
     Route::post('posts', 'create');
-    Route::put('posts/{id}', 'update');
-    Route::delete('posts/{id}', 'delete');
-    Route::get('posts/{id}', 'get');
+    Route::put('posts/{id}', 'update')->whereNumber('id');
+    Route::delete('posts/{id}', 'delete')->whereNumber('id');
+    Route::get('posts/{id}', 'get')->whereNumber('id');
     Route::get('posts', 'search');
 });

--- a/tests/fixtures/ControllerGeneratorTest/api.php
+++ b/tests/fixtures/ControllerGeneratorTest/api.php
@@ -5,8 +5,8 @@ use App\Http\Controllers\PostController;
 
 Route::controller(PostController::class)->group(function () {
     Route::post('posts', 'create');
-    Route::put('posts/{id}', 'update');
-    Route::delete('posts/{id}', 'delete');
-    Route::get('posts/{id}', 'get');
+    Route::put('posts/{id}', 'update')->whereNumber('id');
+    Route::delete('posts/{id}', 'delete')->whereNumber('id');
+    Route::get('posts/{id}', 'get')->whereNumber('id');
     Route::get('posts', 'search');
 });


### PR DESCRIPTION
Added `whereNumber('id')` validation to all routes with id path parameters to enforce numeric-only values. Fixtures updated. All tests pass successfully.